### PR TITLE
Fix neovim crashes

### DIFF
--- a/plugin/qfdiagnostics.vim
+++ b/plugin/qfdiagnostics.vim
@@ -1,3 +1,7 @@
+if !has('vim9script') ||  v:version < 900
+  finish
+endif
+
 vim9script
 # ==============================================================================
 # Highlight quickfix locations and show error messages in popup window


### PR DESCRIPTION
By adding a check for vim9script the plugin doesn't crash for neovim or older vim versions